### PR TITLE
Remove local datacenter from application.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# CHANGELOG
+
+## [1.0.2] - 2020-04-14
+
+Resolves issue #4 by removing the `local-datacenter` parameter from the `application.conf` file, and uses the region
+specified on the command line.
+
+## [1.0.1] - 2020-04-01
+
+Update the POM to reference the latest version of the plugin
+
+## [1.0.0] - 2020-03-17
+
+Initial Release

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>software.aws.mcs</groupId>
     <artifactId>aws-sigv4-auth-cassandra-java-driver-examples</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>AWS SigV4 Auth Java Driver 4.x Examples</name>
     <organization>
         <name>Amazon Web Services</name>

--- a/src/main/java/software/aws/mcs/example/OrderFetcher.java
+++ b/src/main/java/software/aws/mcs/example/OrderFetcher.java
@@ -45,7 +45,7 @@ public class OrderFetcher {
         SigV4AuthProvider provider = new SigV4AuthProvider(args[0]);
         List<InetSocketAddress> contactPoints = Collections.singletonList(new InetSocketAddress(args[1], 9142));
 
-        try (CqlSession session = CqlSession.builder().addContactPoints(contactPoints).withAuthProvider(provider).build()) {
+        try (CqlSession session = CqlSession.builder().addContactPoints(contactPoints).withAuthProvider(provider).withLocalDatacenter(args[0]).build()) {
             // Use a prepared query for quoting
             PreparedStatement prepared = session.prepare("select * from acme.orders where customer_id = ?");
 

--- a/src/main/resources/application-full.conf
+++ b/src/main/resources/application-full.conf
@@ -2,7 +2,6 @@ datastax-java-driver {
     basic.contact-points = [ "cassandra.us-east-2.amazonaws.com:9142" ]
     basic.load-balancing-policy {
         class = DefaultLoadBalancingPolicy
-        local-datacenter = dc1
     }
     advanced {
         auth-provider = {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,7 +1,6 @@
 datastax-java-driver {
     basic.load-balancing-policy {
         class = DefaultLoadBalancingPolicy
-        local-datacenter = dc1
     }
     advanced {
         auth-provider = {


### PR DESCRIPTION
This addresses issue #4 by removing the local datacenter specification from
the `application.conf` file and making it dependent on the specified
region from the command line instead.

Confirmed working with the change:

```
$ java -jar aws-sigv4-auth-cassandra-java-driver-examples-1.0.1.jar us-east-2 cassandra.us-east-2.amazonaws.com 1234
Date                     Order Id
2020-02-26T19:32:51.638Z 2dbedc13-41d0-44c0-94e4-07af54470b03
2020-02-26T19:32:50.999Z 0afaa954-b5a9-43a3-9dfa-d1f190598fed
2020-02-26T19:32:49.916Z 127bcce7-e611-4d72-8dfe-7f11a1489544
2020-02-26T19:31:44.467Z 189ab3bb-05eb-47a4-be66-8a70142ac417
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
